### PR TITLE
Fixed contents menu scroll

### DIFF
--- a/resources/guidance.html
+++ b/resources/guidance.html
@@ -8,7 +8,7 @@
   </head>
     <body>
         <div id="menu" style="grid-column:1;">
-            <h3>Contents</h3>
+            <h4>Contents</h4>
             <ul>
                 <li><a href="#understand">Understand</a></li>
                 <li><a href="#create">Create Metadata</a></li>

--- a/resources/idn.css
+++ b/resources/idn.css
@@ -22,6 +22,8 @@ body {
     border-bottom:solid 10px #ccc;
     background-color: #eee;
     z-index: 100;
+    height: 100dvh;
+    overflow-y: auto;
 }
 #menu > h4 {
     margin-left: 10px;


### PR DESCRIPTION
Fixed the contents menu on the left to scroll if the height exceeds the window.

Resolves #8 

![image](https://github.com/user-attachments/assets/f40584d2-eda7-49a9-b61d-66e5b6e0c816)
