### PR TITLE
Update Data roles vocab link

### DIFF
--- a/resources/specification.html
+++ b/resources/specification.html
@@ -598,7 +598,7 @@
                 <section id="roles">
                     <h3>2.3 Roles <span style="float:right; font-size:smaller;"><a href="">&uparrow;</a></span></h3>
                     <p>All <em>Agents</em>, that is Organisations &amp; People, associated with resources such as datasets in IDN metadata need to have their <em>role</em> defined.</p>
-                    <p>The roles we start with are those defined in the well-known <a href="http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode">ISO's <em>Role Codes</em> vocabulary</a>.</p>
+                    <p>The roles we start with are those defined in the well-known <a href="https://linked.data.gov.au/def/data-roles">ISO's <em>Role Codes</em> vocabulary</a>.</p>
                     <p>This vocabulary contains standard roles such as:</p>
                     <ul>
                         <li>author</li>


### PR DESCRIPTION
Updated link to Data roles vocabulary. Existing one is dead. Changed to the extended version at AGLDWG.