### PR TITLE
Add policy roles vocabulary to profile

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -57,7 +57,7 @@
                     </tr>
                     <tr>
                         <td><a class="proplink" title="sdo:dateModified" href="https://schema.org/dateModified">Modified</a></td>
-                        <td>2023-05-08</td>
+                        <td>2026-07-03</td>
                     </tr>
                 </table>
             </dd>

--- a/profile.html
+++ b/profile.html
@@ -142,6 +142,14 @@
                 <td><a href="https://www.w3.org/TR/skos-reference/">SKOS Simple Knowledge Organization System</a></td>
                 <td>text/turtle, text/html</td>
             </tr>
+            <tr>
+                <td id="https://data.idnau.org/pid/vocab/policy-roles">Policy Roles Vocabulary</td>
+                <td>The Indigenous Data Network's vocabulary of the roles policies play in relation to data governance and data licensing</td>
+                <td><a href="https://data.idnau.org/pid/vocab/policy-roles">https://data.idnau.org/pid/vocab/policy-roles</a></td>
+                <td><a href="http://www.w3.org/ns/dx/prof/role/vocabulary">vocabulary</a></td>
+                <td><a href="https://www.w3.org/TR/skos-reference/">SKOS Simple Knowledge Organization System</a></td>
+                <td>text/turtle, text/html</td>
+            </tr>
             <!--
             <tr>
                 <td id="https://data.idnau.org/pid/vocab/tk-labels">Traditional Knowledge Labels Vocabulary</td>

--- a/profile.ttl
+++ b/profile.ttl
@@ -54,6 +54,13 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         prof:hasRole role:repository ;
     ] ,
     [
+        rdfs:label "Policy Roles Vocabulary" ;
+        rdfs:comment "The Indigenous Data Network's vocabulary of the roles policies play in relation to data governance and data licensing" ;
+        prof:hasArtifact <https://data.idnau.org/pid/vocab/policy-roles> ;
+        dcterms:format "text/turtle, text/html" ;
+        prof:hasRole role:vocabulary ;
+    ] ,
+    [
         rdfs:label "schema.org mapping description" ;
         rdfs:comment "Description of the mappings between IDN CP elements and schema.org elements" ;
         prof:hasArtifact <https://data.idnau.org/pid/cp/sdo> ;

--- a/profile.ttl
+++ b/profile.ttl
@@ -23,7 +23,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sdo:creator <https://orcid.org/0000-0002-8742-7730> ;
     sdo:dateCreated "2022-07-18"^^xsd:date ;
     sdo:dateIssued "2022-07-31"^^xsd:date ;
-    sdo:dateModified "2023-05-08"^^xsd:date ;
+    sdo:dateModified "2026-07-03"^^xsd:date ;
     sdo:description "A profile of cataloguing, provenance and vocabulary standards designed for the representation of Indigenous data governance"@en ;
     sdo:license "https://creativecommons.org/licenses/by/4.0/"^^xsd:anyURI ;
     sdo:name "IDN Catalogue Profile"@en ;

--- a/resources/specification.html
+++ b/resources/specification.html
@@ -165,7 +165,7 @@
           </tr>
           <tr>
             <td><a class="proplink" title="schema:dateModified" href="https://schema.org/dateModified">Modified</a></td>
-            <td>2026-05-26</td>
+            <td>2026-07-03</td>
           </tr>
         </table>
       </dd>

--- a/resources/specification.html
+++ b/resources/specification.html
@@ -666,12 +666,14 @@
             <td>
               <p>The particular policies that are sought are:</p>
               <ul>
-                <li>Indigenous Data Governance Policy</li>
-                <li>general Data Governance Policy</li>
+                <li>Indigenous Data Governance policy</li>
+                <li>Non-Indigenous Data Governance policy ('general' data policy)</li>
                 <li>data license</li>
               </ul>
               <p>Best representation in metadata would be to link to online copies of the policies and to indicate their
-                type from the IDN's <a href="https://data.idnau.org/pid/vocab/policy-types">Policy Types</a> vocabulary
+                role from the IDN's <a href="https://data.idnau.org/pid/vocab/policy-roles">Policy Roles</a>
+                vocabulary. Additionally, you can indicate a type (policy / principle / procedure etc) with the
+                <a href="https://data.idnau.org/pid/vocab/policy-types">Policy Types</a> vocabulary.
               </p>
             </td>
           </tr>


### PR DESCRIPTION
Implements #28. Updates the specification wording for policy roles, adds the Policy Roles vocabulary as a profile resource in `profile.ttl`, and mirrors it in `profile.html` Validation: rapper parsed `profile.ttl` successfully.