### PR TITLE
Use named schema.org mapping resource descriptor

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -57,7 +57,7 @@
                     </tr>
                     <tr>
                         <td><a class="proplink" title="sdo:dateModified" href="https://schema.org/dateModified">Modified</a></td>
-                        <td>2026-07-03</td>
+                        <td>2026-07-08</td>
                     </tr>
                 </table>
             </dd>

--- a/profile.ttl
+++ b/profile.ttl
@@ -23,7 +23,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     sdo:creator <https://orcid.org/0000-0002-8742-7730> ;
     sdo:dateCreated "2022-07-18"^^xsd:date ;
     sdo:dateIssued "2022-07-31"^^xsd:date ;
-    sdo:dateModified "2026-07-03"^^xsd:date ;
+    sdo:dateModified "2026-07-08"^^xsd:date ;
     sdo:description "A profile of cataloguing, provenance and vocabulary standards designed for the representation of Indigenous data governance"@en ;
     sdo:license "https://creativecommons.org/licenses/by/4.0/"^^xsd:anyURI ;
     sdo:name "IDN Catalogue Profile"@en ;
@@ -66,12 +66,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         prof:hasArtifact <https://data.idnau.org/pid/cp/sdo> ;
         prof:hasRole role:mapping ;
     ] ,
-    [
-        rdfs:label "schema.org RDF mapping" ;
-        rdfs:comment "RDF/OWL mappings between IDN CP elements and schema.org elements" ;
-        prof:hasArtifact <https://data.idnau.org/pid/cp/sdo.ttl> ;
-        prof:hasRole role:mapping ;
-    ] ,
+    <https://data.idnau.org/pid/cp/sdo-mapping> ,
     [
         rdfs:label "schema.org conversion script" ;
         rdfs:comment "A Python script that converts IDN CP RDF to schema.org RDF" ;
@@ -88,6 +83,17 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
         <https://www.w3.org/TR/vocab-dcat/> ,
         <https://www.w3.org/TR/skos-reference/> ,
         <https://www.w3.org/TR/prov-o/> ;
+.
+
+<https://data.idnau.org/pid/cp/sdo-mapping>
+    a prof:ResourceDescriptor ;
+    rdfs:label "schema.org RDF mapping" ;
+    rdfs:comment "RDF/OWL mappings between IDN CP elements and schema.org elements" ;
+    sdo:name "schema.org RDF mapping"@en ;
+    sdo:description "The RDF/OWL mapping artifact for IDN Catalogue Profile and schema.org elements."@en ;
+    prof:hasArtifact <https://data.idnau.org/pid/cp/sdo.ttl> ;
+    prof:hasRole role:mapping ;
+    dcterms:format "text/turtle" ;
 .
 
 <https://orcid.org/0000-0002-8742-7730>

--- a/resources/mappings/sdo.ttl
+++ b/resources/mappings/sdo.ttl
@@ -11,10 +11,10 @@ PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-<https://data.idnau.org/pid/cp/sdo.ttl#resource-descriptor>
+<https://data.idnau.org/pid/cp/sdo-mapping>
     a prof:ResourceDescriptor ;
     sdo:name "schema.org RDF mapping"@en ;
-    sdo:description "The RDF/OWL mapping artifact for IDN Catalogue Profile elements and schema.org elements."@en ;
+    sdo:description "The RDF/OWL mapping artifact for IDN Catalogue Profile and schema.org elements."@en ;
     prof:hasArtifact <https://data.idnau.org/pid/cp/sdo.ttl> ;
     prof:hasRole role:mapping ;
     dcterms:format "text/turtle" ;


### PR DESCRIPTION
Refs #35. Refines the schema.org mapping resource descriptor introduced in PR #36: - changes the descriptor IRI to <https://data.idnau.org/pid/cp/sdo-mapping>; updates `profile.ttl` to reference the descriptor by IRI from `prof:hasResource` - preserves `rdfs:label`/ `rdfs:comment` and adds schema.org-ready descriptor metadata;  updates profile modified dates to 2026-07-08