### PR TITLE
Fix person identifier SHACL alternatives

### DIFF
--- a/resources/specification.html
+++ b/resources/specification.html
@@ -2849,10 +2849,12 @@ WHERE {
           property with a <code>xsd:anyURI</code> value or, if a <code>schema:Person</code>, an
           <code>schema:email</code> property with a <code>xsd:anyURI</code> value.</p>
         <p class="req"><strong>Req AG3:</strong> Each <code>Agent</code> instance SHOULD be described with a <code>schema:description</code>
-          property and, if the <code>Agent</code> has them, identifiers for it should be indicated with <code>schema:identifier</code>
-          with either <code>xsd:anyURI</code>, <code>xsd:token</code> or a datatype from the <a
+          property and, if the <code>Agent</code> has them, identifiers for it should be indicated with <code>schema:identifier</code>.
+          Identifier values may use <code>xsd:anyURI</code> or <code>xsd:token</code>. A <code>schema:Person</code> identifier
+          may instead use the <code>id:orcid</code> or <code>id:viaf</code> datatype, while a
+          <code>schema:Organization</code> identifier may instead use an applicable datatype from the <a
                   href="http://id.loc.gov/vocabulary/identifiers" target="_blank" rel="noopener noreferrer">Library of
-            Congress Standard Identifiers</a> vocabulary.</p>
+            Congress Standard Identifiers</a> vocabulary, as constrained by this Profile's validator.</p>
         <p class="req"><strong>Req AG4:</strong> Each <code>Agent</code> MAY relate other information using <em>schema.org</em>
           properties, for example <code>schema:alumniOf</code> to link a <code>schema:Person</code> to an <code>schema:Organization</code>.
         </p>

--- a/resources/validator.ttl
+++ b/resources/validator.ttl
@@ -126,7 +126,7 @@ ont:
     schema:description "IDN shape for Person" ;
     sh:property
         :agent-description ,
-        :agent-identifier ,
+        :person-identifier ,
         :agent-name ,
         :person-email ;
     sh:targetClass schema:Person ;
@@ -340,7 +340,7 @@ ont:
     rdfs:isDefinedBy ont: ;
     schema:name "Agent identifier" ;
     sh:message "Req AG3: Each Agent instance SHOULD be described with a schema:description property and, if the Agent has them, identifiers for it should be indicated with schema:identifier with either xsd:anyURI, xsd:token or a datatype from the Library of Congress Standard Identifiers vocabulary." ;
-    sh:or  (
+    sh:or (
 
         [
             sh:datatype xsd:token ;
@@ -349,7 +349,6 @@ ont:
         [
             sh:datatype xsd:anyURI ;
         ]
-    ) , (
 
         [
             sh:datatype xsd:string ;
@@ -357,10 +356,6 @@ ont:
 
         [
             sh:datatype rdf:langString ;
-        ]
-
-        [
-            sh:datatype id:orcid ;
         ]
 
         [
@@ -377,6 +372,40 @@ ont:
 
         [
             sh:datatype id:ausrn ;
+        ]
+
+        [
+            sh:datatype id:viaf ;
+        ]
+    ) ;
+    sh:path schema:identifier ;
+.
+
+:person-identifier
+    a sh:PropertyShape ;
+    rdfs:isDefinedBy ont: ;
+    schema:name "Person identifier" ;
+    sh:message "Req AG3: Each Person instance SHOULD be described with a schema:description property and, if the Person has them, identifiers for it should be indicated with schema:identifier with either xsd:anyURI, xsd:token or a datatype from the Library of Congress Standard Identifiers vocabulary, including id:orcid." ;
+    sh:or (
+
+        [
+            sh:datatype xsd:token ;
+        ]
+
+        [
+            sh:datatype xsd:anyURI ;
+        ]
+
+        [
+            sh:datatype xsd:string ;
+        ]
+
+        [
+            sh:datatype rdf:langString ;
+        ]
+
+        [
+            sh:datatype id:orcid ;
         ]
 
         [


### PR DESCRIPTION
just loosening things up here so id:orcid datatype can be used for a schema:Person schema:identifier.