### PR TITLE
Relax schema:Person email requirement

### DIFF
--- a/resources/specification.html
+++ b/resources/specification.html
@@ -2846,8 +2846,9 @@ WHERE {
           or a <code>schema:Person</code> instance.</p>
         <p class="req"><strong>Req AG2:</strong> Each <code>Agent</code> instance MUST be described with at least the
           <code>schema:name</code> property and, if an <code>schema:Organization</code>, also an <code>schema:url</code>
-          property with a <code>xsd:anyURI</code> value or, if a <code>schema:Person</code>, an
-          <code>schema:email</code> property with a <code>xsd:anyURI</code> value.</p>
+          property with a <code>xsd:anyURI</code> value. An <code>Agent</code> that is a
+          <code>schema:Person</code> SHOULD be described with a <code>schema:email</code> property with a
+          <code>xsd:anyURI</code> value.</p>
         <p class="req"><strong>Req AG3:</strong> Each <code>Agent</code> instance SHOULD be described with a <code>schema:description</code>
           property and, if the <code>Agent</code> has them, identifiers for it should be indicated with <code>schema:identifier</code>
           with either <code>xsd:anyURI</code>, <code>xsd:token</code> or a datatype from the <a

--- a/resources/validator.ttl
+++ b/resources/validator.ttl
@@ -190,7 +190,7 @@ ont:
     rdfs:isDefinedBy ont: ;
     schema:name "Person email" ;
     sh:datatype xsd:anyURI ;
-    sh:message "Req AG2: Each Agent instance MUST be described with at least the schema:name property and, if an schema:Organization, also an schema:url property with a xsd:anyURI value or, if a schema:Person, an schema:email property with a xsd:anyURI value." ;
+    sh:message "Req AG2: Each Agent instance MUST be described with at least the schema:name property and, if a schema:Organization, also a schema:url property with a xsd:anyURI value. An Agent that is a schema:Person SHOULD be described with a schema:email property with a xsd:anyURI value." ;
     sh:path schema:email ;
 .
 
@@ -199,7 +199,7 @@ ont:
     rdfs:isDefinedBy ont: ;
     schema:name "Agent URL" ;
     sh:datatype xsd:anyURI ;
-    sh:message "Req AG2: Each Agent instance MUST be described with at least the schema:name property and, if an schema:Organization, also an schema:url property with a xsd:anyURI value or, if a schema:Person, an schema:email property with a xsd:anyURI value." ;
+    sh:message "Req AG2: Each Agent instance MUST be described with at least the schema:name property and, if a schema:Organization, also a schema:url property with a xsd:anyURI value. An Agent that is a schema:Person SHOULD be described with a schema:email property with a xsd:anyURI value." ;
     sh:path schema:url ;
 .
 
@@ -258,7 +258,7 @@ ont:
     schema:name "Organization URL" ;
     sh:datatype xsd:anyURI ;
     sh:maxCount 1 ;
-    sh:message "Req AG2: (organization-email) Each Agent instance MUST be described with at least the schema:name property and, if an schema:Organization, also an schema:url property with a xsd:anyURI value or, if a schema:Person, an schema:email property with a xsd:anyURI value." ;
+    sh:message "Req AG2: (organization-url) Each Agent instance MUST be described with at least the schema:name property and, if a schema:Organization, also a schema:url property with a xsd:anyURI value. An Agent that is a schema:Person SHOULD be described with a schema:email property with a xsd:anyURI value." ;
     sh:minCount 1 ;
     sh:path schema:url ;
 .
@@ -269,8 +269,7 @@ ont:
     schema:name "Person email" ;
     sh:datatype xsd:anyURI ;
     sh:maxCount 1 ;
-    sh:message "Req AG2: (person-email) Each Agent instance MUST be described with at least the schema:name property and, if an schema:Organization, also an schema:url property with a xsd:anyURI value or, if a schema:Person, an schema:email property with a xsd:anyURI value." ;
-    sh:minCount 1 ;
+    sh:message "Req AG2: (person-email) Each Agent instance MUST be described with at least the schema:name property and, if a schema:Organization, also a schema:url property with a xsd:anyURI value. An Agent that is a schema:Person SHOULD be described with a schema:email property with a xsd:anyURI value." ;
     sh:path schema:email ;
 .
 
@@ -391,7 +390,7 @@ ont:
     rdfs:isDefinedBy ont: ;
     schema:name "Agent name" ;
     sh:maxCount 1 ;
-    sh:message "Req AG2: Each Agent instance MUST be described with at least the schema:name property and, if an schema:Organization, also an schema:url property with a xsd:anyURI value or, if a schema:Person, an schema:email property with a xsd:anyURI value." ;
+    sh:message "Req AG2: Each Agent instance MUST be described with at least the schema:name property and, if a schema:Organization, also a schema:url property with a xsd:anyURI value. An Agent that is a schema:Person SHOULD be described with a schema:email property with a xsd:anyURI value." ;
     sh:minCount 1 ;
     sh:or (
 


### PR DESCRIPTION
## Summary

- update Req AG2 so `schema:email` is recommended rather than mandatory for `schema:Person`
- remove the SHACL minimum-count requirement for person email while retaining `xsd:anyURI` datatype and maximum-count validation
- align AG2 validation messages and correct the organization URL constraint label

## Impact

Person records without an email address no longer produce a SHACL violation. Supplied email values must still conform to the existing constraint.

## Validation

- `riot --validate resources/validator.ttl`
- `rapper -i turtle -c resources/validator.ttl`
- focused Kurra SHACL checks: person without email passes; person with a non-`xsd:anyURI` email fails
- `uv run pytest` (existing unrelated failure: `MPF1226.ttl` violates Req R1 identifier validation)
- `git diff --check`

Fixes #42